### PR TITLE
move logic for 'env' file to hod.local, use log.error

### DIFF
--- a/hod/subcommands/connect.py
+++ b/hod/subcommands/connect.py
@@ -37,25 +37,20 @@ import sys
 from vsc.utils import fancylogger
 from vsc.utils.generaloption import GeneralOption
 
-from hod import VERSION as HOD_VERSION
+from hod.local import cluster_env_file
 from hod.subcommands.subcommand import SubCommand
+import hod
 import hod.rmscheduler.rm_pbs as rm_pbs
 
 
 _log = fancylogger.getLogger(fname=False)
 
-def default_cluster_path():
-    '''
-    Return $XDG_CONFIG_HOME/hod.d or $HOME/.local/hod.d
-    http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
-    '''
-    dflt = os.path.join(os.getenv('HOME'), '.config')
-    return os.path.join(os.getenv('XDG_CONFIG_HOME', dflt), 'hod.d')
 
 class ConnectOptions(GeneralOption):
     """Option parser for 'list' subcommand."""
-    VERSION = HOD_VERSION
+    VERSION = hod.VERSION
     ALLOPTSMANDATORY = False # let us use optionless arguments.
+
 
 class ConnectSubCommand(SubCommand):
     """
@@ -76,32 +71,26 @@ class ConnectSubCommand(SubCommand):
             if len(optparser.args) > 1:
                 jobid = optparser.args[1]
             else:
-                sys.stderr.write('No jobid provided.\n')
-                return 1
+                _log.error("No jobid provided.")
+                sys.exit(1)
 
-            cluster_dir = default_cluster_path()
-            clusters = os.listdir(cluster_dir)
-
-            if jobid not in clusters:
-                sys.stderr.write('No env found for job %s\n' % jobid)
-                return 1
+            env_script = cluster_env_file(jobid)
 
             pbs = rm_pbs.Pbs(optparser)
             jobs = pbs.state()
             pbsjobs = [job for job in jobs if job.jid == jobid]
 
             if len(pbsjobs) == 0:
-                sys.stderr.write('Job %s not found by pbs.\n' % jobid)
-                return 1
+                _log.error("Job %s not found by pbs.", jobid)
+                sys.exit(1)
 
             pbsjob = pbsjobs[0]
             if pbsjob.state == ['Q', 'H']:
                 # This should never happen since the hod.d/<jobid>/env file is
                 # written on cluster startup. Maybe someone hacked the dirs.
-                sys.stderr.write("Cannot connect to %s yet. It is still queued.\n" % jobid)
-                return 1
+                _log.error("Cannot connect to %s yet. It is still queued.", jobid)
+                sys.exit(1)
 
-            env_script = os.path.join(cluster_dir, jobid, 'env')
             os.execvp('/usr/bin/ssh', ['ssh', '-t', pbsjob.ehosts, 'exec', 'bash', '--rcfile', env_script, '-i'])
             return 0 # pragma: no cover
 
@@ -109,4 +98,3 @@ class ConnectSubCommand(SubCommand):
             fancylogger.setLogFormat(fancylogger.TEST_LOGGING_FORMAT)
             fancylogger.logToScreen(enable=True)
             _log.raiseException(err.message)
-


### PR DESCRIPTION
I'd like to keep the functionality to create & grab the 'env' file in one place, `hod.local` makes sense to me.

Please review/merge, I'll implement `create_env_file` later, and maybe also tackle support for custom cluster labels rather than sticking to `jobid`.